### PR TITLE
jtimon is now using golang's dep tool so we no longer need to have "go get ..."

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,18 +4,13 @@
 FROM alpine:3.7
 RUN apk add --no-cache ethtool
 RUN apk add --no-cache --virtual build-dependencies git go musl-dev \
-  && go get github.com/golang/protobuf/proto \
-  && go get github.com/gorilla/mux \
-  && go get github.com/influxdata/influxdb/client/v2 \
-  && go get github.com/prometheus/client_golang/prometheus/promhttp \
-  && go get github.com/spf13/pflag \
-  && go get golang.org/x/net/context \
-  && go get google.golang.org/grpc \
-  && go get github.com/nileshsimaria/jtimon/telemetry \
-  && go get github.com/nileshsimaria/jtimon/authentication \
+  && mkdir -p /root/go/src/github.com/nileshsimaria \
+  && cd /root/go/src/github.com/nileshsimaria \
   && git clone https://github.com/nileshsimaria/jtimon.git \
   && cd jtimon && go build && strip jtimon && mv jtimon /usr/local/bin \
-  && cd .. && rm -rf jtimon && apk del build-dependencies
+  && cd / \
+  && rm -fr /root/go \
+  && apk del build-dependencies
 
 VOLUME /u
 WORKDIR /u


### PR DESCRIPTION
for dependent go packages in Dockerfile. The advantage is if in future
jtimon brings in new go package as dependent package we do not need to
modify Dockerfile.