### PR TITLE
Closing the connection before attempting to reconnect

### DIFF
--- a/main.go
+++ b/main.go
@@ -206,6 +206,8 @@ func worker(file string, idx int, wg *sync.WaitGroup) (chan bool, error) {
 						}
 
 						subscribe(conn, &jctx)
+						// Close the current connection and retry
+						conn.Close()
 						// If we are here we must try to reconnect again.
 						// Reconnect after 10 seconds.
 						time.Sleep(10 * time.Second)


### PR DESCRIPTION
Before retrying for a new connection, Close the older connections