### PR TITLE
Parsing of multiple keys for influxdb

### DIFF
--- a/influx_test.go
+++ b/influx_test.go
@@ -9,7 +9,8 @@ import (
 func TestSpitTagsNPath(t *testing.T) {
 	jctx := &JCtx{
 		influxCtx: InfluxCtx{
-			re: regexp.MustCompile(MatchExpression),
+			reXpath: regexp.MustCompile(MatchExpressionXpath),
+			reKey:   regexp.MustCompile(MatchExpressionKey),
 		},
 	}
 
@@ -43,6 +44,16 @@ func TestSpitTagsNPath(t *testing.T) {
 			"/junos/chassis/cmerror/counters/error",
 			map[string]string{
 				"/junos/chassis/cmerror/counters/@name": "/fpc/1/pfe/0/cm/0/CM0/0/CM_CMERROR_FABRIC_REMOTE_PFE_RATE",
+			},
+		},
+		{
+			"/junos/events/event[id='SYSTEM' and type='3' and facility='5']/attributes[key='message']/",
+			"/junos/events/event/attributes/",
+			map[string]string{
+				"/junos/events/event/@id":             "SYSTEM",
+				"/junos/events/event/@type":           "3",
+				"/junos/events/event/@facility":       "5",
+				"/junos/events/event/attributes/@key": "message",
 			},
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -25,8 +25,9 @@ import (
 const (
 	// DefaultGRPCWindowSize is the default GRPC Window Size
 	DefaultGRPCWindowSize = 1048576
-	// MatchExpression is for the patter matching
-	MatchExpression = "\\/([^\\/]*)\\[([A-Za-z0-9\\-\\/]*)\\=([^\\[]*)\\]"
+	// MatchExpression is for the pattern matching
+	MatchExpressionXpath = "\\/([^\\/]*)\\[(.*?)+?(?:\\])"
+	MatchExpressionKey   = "([A-Za-z0-9-/]*)=(.*?)?(?:and|$)+"
 )
 
 var (


### PR DESCRIPTION
The telemetry data can have mutiple keys in its xpath data. These keyelements needs to be parsed seperately. Currenty JTIMON supports only parsing of single key. 

Telemetry Data
  str_value:/junos/events/event[id='SYSTEM' and type='3' and facility='5']/attributes[key='message']/

Influx DB Messages to be written in the database

/junos/events/event/@id = ‘SYSTEM’
/junos/events/event/@type = ‘3’
/junos/events/event/@facility = ‘5’
/junos/events/event/attributes/@key = ‘message’
/junos/events/event/attributes/value = ‘Subscribing sensor_1002’


Fix:
The String data is parsed using regex, Regex is enhanced to parse this data. 


Build and Test Logs
==============

balasank@ubuntu:~/workspace/src/github.com/nileshsimaria/jtimon$ go build
balasank@ubuntu:~/workspace/src/github.com/nileshsimaria/jtimon$ make tests
make: Nothing to be done for 'tests'.
balasank@ubuntu:~/workspace/src/github.com/nileshsimaria/jtimon$ make test
go test -v
=== RUN   TestNewJTIMONConfig
--- PASS: TestNewJTIMONConfig (0.00s)
=== RUN   TestValidateConfig
--- PASS: TestValidateConfig (0.00s)
=== RUN   TestExploreConfig
--- PASS: TestExploreConfig (0.00s)
=== RUN   TestSpitTagsNPath
--- PASS: TestSpitTagsNPath (0.00s)
=== RUN   TestSubscriptionPathFromPath
--- PASS: TestSubscriptionPathFromPath (0.00s)
PASS
ok  	github.com/nileshsimaria/jtimon	0.012s


Testcase are added in influx_test.go

