### PR TITLE
Config change handling through SIGHUP

### DIFF
--- a/config.go
+++ b/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	Influx   InfluxConfig  `json:"influx"`
 	Paths    []PathsConfig `json:"paths"`
 	Log      LogConfig     `json:"log"`
+	// mux      sync.RWMutex
 }
 
 //LogConfig is config struct for logging

--- a/config.go
+++ b/config.go
@@ -237,11 +237,10 @@ func ConfigRead(jctx *JCtx, init bool) error {
 		err := ValidateConfigChange(jctx, config)
 		if err == nil {
 			jctx.config.Paths = config.Paths
-			jLog(jctx, fmt.Sprintf("We have got a new config\n"))
+			jLog(jctx, fmt.Sprintf("Config has been updated\n"))
 		} else {
-			jLog(jctx, fmt.Sprintf("Ignoring config changes\n"))
+			return fmt.Errorf("No change in subscription path, ignoring config changes")
 		}
-		jLog(jctx, fmt.Sprintf("Config has been updated\n"))
 	}
 
 	return nil
@@ -268,6 +267,7 @@ func HandleConfigChanges(cfgFileList *string, wMap map[string]*workerCtx,
 	configfilelist, err := NewJTIMONConfigFilelist(*cfgFileList)
 	if err != nil {
 		fmt.Printf("Error in parsing the new config file, Continuing with older config")
+		return
 	}
 
 	s := syscall.SIGHUP

--- a/config.go
+++ b/config.go
@@ -171,7 +171,6 @@ func GetConfigFiles(cfgFile *[]string, cfgFileList *string) error {
 		}
 		n := len(configfilelist.Filenames)
 		if n == 0 {
-
 			return fmt.Errorf("File list doesn't have any files in %v", *cfgFileList)
 		}
 		*cfgFile = configfilelist.Filenames

--- a/config_test.go
+++ b/config_test.go
@@ -89,7 +89,7 @@ func TestStringInSlice(t *testing.T) {
 	configfilelist := []string{"one", "two", "three"}
 
 	for _, file := range files {
-		ret := stringInSlice(file.name, configfilelist)
+		ret := StringInSlice(file.name, configfilelist)
 		if ret != file.value {
 			t.Errorf("TeststringInSlice failed")
 		}

--- a/config_test.go
+++ b/config_test.go
@@ -76,7 +76,7 @@ func TestExploreConfig(t *testing.T) {
 	}
 }
 
-func TeststringInSlice(t *testing.T) {
+func TestStringInSlice(t *testing.T) {
 	files := []struct {
 		name  string
 		value bool

--- a/config_test.go
+++ b/config_test.go
@@ -75,3 +75,23 @@ func TestExploreConfig(t *testing.T) {
 		t.Errorf("ExploreConfig failed, Error: %v\n", err)
 	}
 }
+
+func TeststringInSlice(t *testing.T) {
+	files := []struct {
+		name  string
+		value bool
+	}{
+		{"first", false},
+		{"two", true},
+		{"third", false},
+	}
+
+	configfilelist := []string{"one", "two", "three"}
+
+	for _, file := range files {
+		ret := stringInSlice(file.name, configfilelist)
+		if ret != file.value {
+			t.Errorf("TeststringInSlice failed")
+		}
+	}
+}

--- a/logs.go
+++ b/logs.go
@@ -25,38 +25,29 @@ func logInit(jctx *JCtx) {
 
 	file := jctx.config.Log.File
 	var out io.Writer
-	change := false // Dummy now
 
-	if !change {
-		if *print {
-			out = os.Stdout
-			if file != "" {
-				log.Println("Both print and log options are used, ignoring log")
-			}
-		} else if file != "" {
-			var err error
-			out, err = os.OpenFile(file, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
-			if err != nil {
-				log.Printf("Could not create log file(%s): %v\n", file, err)
-			}
+	if *print {
+		out = os.Stdout
+		if file != "" {
+			log.Println("Both print and log options are used, ignoring log")
+		}
+	} else if file != "" {
+		var err error
+		out, err = os.OpenFile(file, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+		if err != nil {
+			log.Printf("Could not create log file(%s): %v\n", file, err)
+		}
+	}
+
+	if out != nil {
+		flags := 0
+		if !jctx.config.Log.CSVStats {
+			flags = log.LstdFlags
 		}
 
-		if out != nil {
-			flags := 0
-			if !jctx.config.Log.CSVStats {
-				flags = log.LstdFlags
-			}
-
-			jctx.config.Log.Logger = log.New(out, "", flags)
-			log.Printf("logging in %s for %s:%d [periodic stats every %d seconds]\n",
-				jctx.config.Log.File, jctx.config.Host, jctx.config.Port, jctx.config.Log.PeriodicStats)
-
-		}
-	} else {
-		if jctx.config.Log.Logger != nil {
-			out, _ = os.OpenFile("newfile", os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
-			jctx.config.Log.Logger = log.New(out, "", log.LstdFlags)
-		}
+		jctx.config.Log.Logger = log.New(out, "", flags)
+		log.Printf("logging in %s for %s:%d [periodic stats every %d seconds]\n",
+			jctx.config.Log.File, jctx.config.Host, jctx.config.Port, jctx.config.Log.PeriodicStats)
 
 	}
 }

--- a/logs.go
+++ b/logs.go
@@ -25,29 +25,38 @@ func logInit(jctx *JCtx) {
 
 	file := jctx.config.Log.File
 	var out io.Writer
+	change := false // Dummy now
 
-	if *print {
-		out = os.Stdout
-		if file != "" {
-			log.Println("Both print and log options are used, ignoring log")
-		}
-	} else if file != "" {
-		var err error
-		out, err = os.OpenFile(file, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
-		if err != nil {
-			log.Printf("Could not create log file(%s): %v\n", file, err)
-		}
-	}
-
-	if out != nil {
-		flags := 0
-		if !jctx.config.Log.CSVStats {
-			flags = log.LstdFlags
+	if !change {
+		if *print {
+			out = os.Stdout
+			if file != "" {
+				log.Println("Both print and log options are used, ignoring log")
+			}
+		} else if file != "" {
+			var err error
+			out, err = os.OpenFile(file, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+			if err != nil {
+				log.Printf("Could not create log file(%s): %v\n", file, err)
+			}
 		}
 
-		jctx.config.Log.Logger = log.New(out, "", flags)
-		log.Printf("logging in %s for %s:%d [periodic stats every %d seconds]\n",
-			jctx.config.Log.File, jctx.config.Host, jctx.config.Port, jctx.config.Log.PeriodicStats)
+		if out != nil {
+			flags := 0
+			if !jctx.config.Log.CSVStats {
+				flags = log.LstdFlags
+			}
+
+			jctx.config.Log.Logger = log.New(out, "", flags)
+			log.Printf("logging in %s for %s:%d [periodic stats every %d seconds]\n",
+				jctx.config.Log.File, jctx.config.Host, jctx.config.Port, jctx.config.Log.PeriodicStats)
+
+		}
+	} else {
+		if jctx.config.Log.Logger != nil {
+			out, _ = os.OpenFile("newfile", os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+			jctx.config.Log.Logger = log.New(out, "", log.LstdFlags)
+		}
 
 	}
 }

--- a/main.go
+++ b/main.go
@@ -69,7 +69,6 @@ type JCtx struct {
 		pch   chan int64
 		upch  chan struct{}
 		subch chan struct{}
-		logch chan struct{}
 	}
 	running bool
 }
@@ -106,7 +105,7 @@ func worker(file string, idx int, wg *sync.WaitGroup) (chan<- os.Signal, error) 
 				case os.Interrupt:
 					// Received Interrupt Signal, Stop the program
 					printSummary(&jctx)
-					wg.Done()
+					jctx.wg.Done()
 				case syscall.SIGHUP:
 					// Handle SIGHUP if the streaming is happening
 					// Running will not be set when the connection is
@@ -225,7 +224,7 @@ func worker(file string, idx int, wg *sync.WaitGroup) (chan<- os.Signal, error) 
 				case false:
 					// Exited with error
 					printSummary(&jctx)
-					wg.Done()
+					jctx.wg.Done()
 				case true:
 					jctx.running = true
 				}

--- a/subscribe.go
+++ b/subscribe.go
@@ -221,10 +221,10 @@ func subscribe(conn *grpc.ClientConn, jctx *JCtx, statusch chan<- bool) {
 
 		res := subSendAndReceive(conn, jctx, subReqM, statusch)
 		if res != SubRcRestartStreaming {
-			fmt.Println("Restarting the connection")
+			jLog(jctx, fmt.Sprintf("Restarting the connection\n"))
 			// Restart the connection
 			return
 		}
-		fmt.Println("Restarting Subscription")
+		jLog(jctx, fmt.Sprintf("Restarting Subscription\n"))
 	}
 }

--- a/subscribe.go
+++ b/subscribe.go
@@ -127,6 +127,9 @@ func subSendAndReceive(conn *grpc.ClientConn, jctx *JCtx,
 	}
 
 	datach := make(chan struct{})
+
+	// Inform the caller that streaming has started. 
+	statusch <- true
 	go func() {
 		// Go Routine which actually starts the streaming connection and receives the data
 		jLog(jctx, fmt.Sprintf("Receiving telemetry data from %s:%d\n", jctx.config.Host, jctx.config.Port))
@@ -181,10 +184,9 @@ func subSendAndReceive(conn *grpc.ClientConn, jctx *JCtx,
 		}
 	}()
 	for {
-		// The below select loop will hand
+		// The below select loop will handle the following 
+		// 		1. Tell the caller that streaming has started
 		select {
-		case statusch <- true:
-			fmt.Println("Streaming has started")
 		case <-jctx.pause.subch:
 			// Config has been updated restart the streaming.
 			// Need to find a way to close the streaming.


### PR DESCRIPTION
1. SIGHUP will be handled in JTIMON and it will treated as config change
2. SIgnals are propagated from main to worker and then go to routine where the thread will be blocked and the config is read again. 
3. The Subscription will get restarted with a fresh config. 
4. The config changes are handled for config-list option only
    - The filenames in the config list implies add or modification on comparision with the running config. 
    - If the filenames is not found then it will be considered as deleted. 