### PR TITLE
Retry in case of failure from logincheck API

### DIFF
--- a/main.go
+++ b/main.go
@@ -208,13 +208,15 @@ func worker(file string, idx int, wg *sync.WaitGroup) (chan<- os.Signal, error) 
 										Password: pass, ClientId: jctx.config.CID})
 								if err != nil {
 									jLog(&jctx, fmt.Sprintf("[%d] Could not login: %v\n", idx, err))
-									statusch <- false
-									return
+									time.Sleep(10 * time.Second)
+									retry = true
+									goto connect
 								}
 								if !dat.Result {
 									jLog(&jctx, fmt.Sprintf("[%d] LoginCheck failed", idx))
-									statusch <- false
-									return
+									time.Sleep(10 * time.Second)
+									retry = true
+									goto connect
 								}
 							}
 						}


### PR DESCRIPTION
JTIMON exits when there is a Username/Password authentication failure. 
 
This can happen in the following scenario 
  1. Users provides the wrong username/password to the JTIMON
        - JTIMON has to be restarted with the correct config
  2. User is yet to configure the credentials in the router. 
       - JTIMON can keep retrying till the device is configured with the credentials 
  3. Device rejects the connection on Maximum connection limit. 
       - JTIMON can keep retrying till the connection is accepted. 
  4. For skip authentication, the subscribe API will retry incase if there is port mismatch. 


Logs 
```
2018/11/20 14:35:50 Connecting to 10.209.1.220:32767
2018/11/20 14:35:50 [0] LoginCheck failed
2018/11/20 14:36:00 Reconnecting to 10.209.1.220:32767
2018/11/20 14:36:00 [0] LoginCheck failed
```

```
2018/11/20 14:37:33 Reconnecting to 10.209.1.220:32767
2018/11/20 14:37:34 [0] Could not login: rpc error: code = Unavailable desc = JGrpcServer: Max Client connection limit reached
2018/11/20 14:37:44 Reconnecting to 10.209.1.220:32767
2018/11/20 14:37:44 [0] Could not login: rpc error: code = Unavailable desc = JGrpcServer: Max Client connection limit reached
```

   
