### PR TITLE
Fix regex to accept "and" substring in keyname

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -14,5 +14,5 @@ const (
 	// MatchExpressionXpath is for the pattern matching the xpath and key-value pairs
 	MatchExpressionXpath = "\\/([^\\/]*)\\[(.*?)+?(?:\\])"
 	// MatchExpressionKey is for pattern matching the single and multiple key value pairs
-	MatchExpressionKey = "([A-Za-z0-9-/]*)=(.*?)?(?:and|$)+"
+	MatchExpressionKey = "([A-Za-z0-9-/]*)=(.*?)?(?: and |$)+"
 )

--- a/influx_test.go
+++ b/influx_test.go
@@ -62,6 +62,15 @@ func TestSpitTagsNPath(t *testing.T) {
 				"/junos/events/event/attributes/@key": "message",
 			},
 		},
+		{
+			"events-2",
+			"/junos/rpm/history-results/history-test-results/history-single-test-results[owner='orlando' and test-name='orlando']/",
+			"/junos/rpm/history-results/history-test-results/history-single-test-results/",
+			map[string]string{
+				"/junos/rpm/history-results/history-test-results/history-single-test-results/@owner":     "orlando",
+				"/junos/rpm/history-results/history-test-results/history-single-test-results/@test-name": "orlando",
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Issue:  Regex is not able to trimming the string when "and" is the key value

strings :  "/junos/rpm/history-results/history-test-results/history-single-test-results[owner='orlando' and test-name='orlando']/"
Expected : orlando
Getting : orl
 
Fix : Have space around regex
Tests have been added to the same.