### PR TITLE
decode the password if decode-util was provided in the config

### DIFF
--- a/config.go
+++ b/config.go
@@ -19,21 +19,21 @@ type ConfigFileList struct {
 
 // Config struct
 type Config struct {
-	Port       int           `json:"port"`
-	Host       string        `json:"host"`
-	User       string        `json:"user"`
-	Password   string        `json:"password"`
-	CID        string        `json:"cid"`
-	Meta       bool          `json:"meta"`
-	EOS        bool          `json:"eos"`
-	GRPC       GRPCConfig    `json:"grpc"`
-	TLS        TLSConfig     `json:"tls"`
-	Influx     InfluxConfig  `json:"influx"`
-	Paths      []PathsConfig `json:"paths"`
-	Log        LogConfig     `json:"log"`
-	Vendor     VendorConfig  `json:"vendor"`
-	Alias      string        `json:"alias"`
-	DecodeUtil string        `json:"decode-util"`
+	Port            int           `json:"port"`
+	Host            string        `json:"host"`
+	User            string        `json:"user"`
+	Password        string        `json:"password"`
+	CID             string        `json:"cid"`
+	Meta            bool          `json:"meta"`
+	EOS             bool          `json:"eos"`
+	GRPC            GRPCConfig    `json:"grpc"`
+	TLS             TLSConfig     `json:"tls"`
+	Influx          InfluxConfig  `json:"influx"`
+	Paths           []PathsConfig `json:"paths"`
+	Log             LogConfig     `json:"log"`
+	Vendor          VendorConfig  `json:"vendor"`
+	Alias           string        `json:"alias"`
+	PasswordDecoder string        `json:"password-decoder"`
 }
 
 // VendorConfig definition
@@ -231,9 +231,9 @@ func ConfigRead(jctx *JCtx, init bool) error {
 
 		jLog(jctx, fmt.Sprintf("Running config of JTIMON:\n %s", string(b)))
 		// Decode the password if the config has provided the decode util
-		if len(config.DecodeUtil) > 0 {
+		if len(config.PasswordDecoder) > 0 {
 			// Run the decode util with the input file as argument
-			cmd := exec.Command(config.DecodeUtil, jctx.file)
+			cmd := exec.Command(config.PasswordDecoder, jctx.file)
 			var stdout, stderr bytes.Buffer
 			cmd.Stdout = &stdout
 			cmd.Stderr = &stderr

--- a/config.go
+++ b/config.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
+	"os/exec"
 	"reflect"
 )
 
@@ -17,20 +19,21 @@ type ConfigFileList struct {
 
 // Config struct
 type Config struct {
-	Port     int           `json:"port"`
-	Host     string        `json:"host"`
-	User     string        `json:"user"`
-	Password string        `json:"password"`
-	CID      string        `json:"cid"`
-	Meta     bool          `json:"meta"`
-	EOS      bool          `json:"eos"`
-	GRPC     GRPCConfig    `json:"grpc"`
-	TLS      TLSConfig     `json:"tls"`
-	Influx   InfluxConfig  `json:"influx"`
-	Paths    []PathsConfig `json:"paths"`
-	Log      LogConfig     `json:"log"`
-	Vendor   VendorConfig  `json:"vendor"`
-	Alias    string        `json:"alias"`
+	Port       int           `json:"port"`
+	Host       string        `json:"host"`
+	User       string        `json:"user"`
+	Password   string        `json:"password"`
+	CID        string        `json:"cid"`
+	Meta       bool          `json:"meta"`
+	EOS        bool          `json:"eos"`
+	GRPC       GRPCConfig    `json:"grpc"`
+	TLS        TLSConfig     `json:"tls"`
+	Influx     InfluxConfig  `json:"influx"`
+	Paths      []PathsConfig `json:"paths"`
+	Log        LogConfig     `json:"log"`
+	Vendor     VendorConfig  `json:"vendor"`
+	Alias      string        `json:"alias"`
+	DecodeUtil string        `json:"decode-util"`
 }
 
 // VendorConfig definition
@@ -227,7 +230,21 @@ func ConfigRead(jctx *JCtx, init bool) error {
 		}
 
 		jLog(jctx, fmt.Sprintf("Running config of JTIMON:\n %s", string(b)))
-
+		// Decode the password if the config has provided the decode util
+		if len(config.DecodeUtil) > 0 {
+			// Run the decode util with the input file as argument
+			cmd := exec.Command(config.DecodeUtil, jctx.file)
+			var stdout, stderr bytes.Buffer
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+			err := cmd.Run()
+			outStr, errStr := string(stdout.Bytes()), string(stderr.Bytes())
+			if err != nil {
+				log.Fatalf("cmd.Run() failed with %s:%s\n", err, errStr)
+				return err
+			}
+			jctx.config.Password = outStr
+		}
 		// subscription channel (subch) is used to let go routine receiving telemetry
 		// data know about certain events like sighup.
 		jctx.control = make(chan os.Signal)


### PR DESCRIPTION
* JTIMON can receive the password in encoded and plain text format. 
* If the password is encoded then the caller is expected to provide the decode utility which can decode the password.  
* `password-decoder` has been added to config which needs to contain the location of the decoder
* password-decoder will be called and the encoded password will be converted and used by JTIMON for connecting to the devices
