### PR TITLE
Enable binding Prometheus metrics to interfaces other than loopback

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ var (
 	versionOnly    = flag.Bool("version", false, "Print version and build-time of the binary and exit")
 	compression    = flag.String("compression", "", "Enable HTTP/2 compression (gzip)")
 	prom           = flag.Bool("prometheus", false, "Stats for prometheus monitoring system")
+	promHost       = flag.String("prometheus-host", "127.0.0.1", "IP to bind Prometheus service to")
 	promPort       = flag.Int32("prometheus-port", 8090, "Prometheus port")
 	prefixCheck    = flag.Bool("prefix-check", false, "Report missing __prefix__ in telemetry packet")
 	pProf          = flag.Bool("pprof", false, "Profile JTIMON")

--- a/prometheus_exporter.go
+++ b/prometheus_exporter.go
@@ -176,7 +176,7 @@ func promInit() *jtimonPExporter {
 	go func() {
 		go c.processJTIMONMetric()
 
-		addr := fmt.Sprintf("localhost:%d", *promPort)
+		addr := fmt.Sprintf("%s:%d", *promHost,  *promPort)
 		http.Handle("/metrics", promhttp.Handler())
 		fmt.Println(http.ListenAndServe(addr, nil))
 	}()


### PR DESCRIPTION
When using jtimon in a containerized deployment one would need to be able to expose the /metrics service globally (e.g. binding to 0.0.0.0). Currently, binding to localhost is hardcoded. This small PR adds the  parameter `--prometheus-host` so the binding interface can be chosen arbitrarily.

Default behaviour is not changed as the parameter defaults to 127.0.0.1.
