### PR TITLE
Convert strings that only contain numbers into floats

### DIFF
--- a/prometheus_exporter.go
+++ b/prometheus_exporter.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -149,6 +150,12 @@ func addPrometheus(ocData *na_pb.OpenConfigData, jctx *JCtx) {
 			} else {
 				fieldValue = 0
 			}
+		case *na_pb.KeyValue_StrValue:
+			floatVal, err := strconv.ParseFloat(v.GetStrValue(), 64)
+			if err != nil {
+				continue
+			}
+			fieldValue = floatVal
 		default:
 			continue
 		}
@@ -176,7 +183,7 @@ func promInit() *jtimonPExporter {
 	go func() {
 		go c.processJTIMONMetric()
 
-		addr := fmt.Sprintf("%s:%d", *promHost,  *promPort)
+		addr := fmt.Sprintf("%s:%d", *promHost, *promPort)
 		http.Handle("/metrics", promhttp.Handler())
 		fmt.Println(http.ListenAndServe(addr, nil))
 	}()


### PR DESCRIPTION
Converting strings into floats allows them to then be exported to prometheus.
For example /components/component/properties/property/temperature is stored as a string but contains a number such as 28 which identifies the component's temperature in degree celsius. 

go fmt was also run, which cleaned up another line in the document.