### PR TITLE
Prometheus: Ability to drop key prefix from labels

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	Vendor          VendorConfig  `json:"vendor"`
 	Alias           string        `json:"alias"`
 	PasswordDecoder string        `json:"password-decoder"`
+	DropTagPrefix	bool          `json:"dropTagPrefix"`
 }
 
 // VendorConfig definition

--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ type Config struct {
 	Vendor          VendorConfig  `json:"vendor"`
 	Alias           string        `json:"alias"`
 	PasswordDecoder string        `json:"password-decoder"`
-	DropTagPrefix	bool          `json:"dropTagPrefix"`
+	DropLabelPrefix bool          `json:"dropLabelPrefix"`
 }
 
 // VendorConfig definition

--- a/prometheus_exporter.go
+++ b/prometheus_exporter.go
@@ -19,8 +19,13 @@ var (
 )
 
 // Prometheus does not like special characters, handle them.
-func promName(input string) string {
-	return promNameRegex.ReplaceAllString(input, "_")
+func promName(input string, dropPrefix bool) string {
+	convStr := promNameRegex.ReplaceAllString(input, "_")
+	if dropPrefix {
+		strParts := strings.Split(convStr, "_")
+		convStr = strParts[len(strParts)-1]
+	}
+	return convStr
 }
 
 type jtimonMetric struct {
@@ -154,13 +159,13 @@ func addPrometheus(ocData *na_pb.OpenConfigData, jctx *JCtx) {
 		}
 
 		metric := &jtimonMetric{
-			metricName:       promName(field),
+			metricName:       promName(field, false),
 			metricExpiration: time.Now(),
 			metricValue:      fieldValue,
 			metricLabels:     map[string]string{},
 		}
 		for k, v := range tags {
-			metric.metricLabels[promName(k)] = v
+			metric.metricLabels[promName(k, cfg.DropTagPrefix)] = v
 		}
 
 		metric.mapKey = getMapKey(metric)

--- a/prometheus_exporter.go
+++ b/prometheus_exporter.go
@@ -165,7 +165,7 @@ func addPrometheus(ocData *na_pb.OpenConfigData, jctx *JCtx) {
 			metricLabels:     map[string]string{},
 		}
 		for k, v := range tags {
-			metric.metricLabels[promName(k, cfg.DropTagPrefix)] = v
+			metric.metricLabels[promName(k, cfg.DropLabelPrefix)] = v
 		}
 
 		metric.mapKey = getMapKey(metric)


### PR DESCRIPTION
Default behaviour is to simply replace all special characters in the label path with underscores. This leads to very long label names like these:
`_interfaces_interface__name="et-0/0/0"`

This PR introduces a config parameter `dropLabelPrefix` which will split all labels for a given metric by underscores and only keep the last part. Sticking with the example above, this label would be replaced by `name="et-0/0/0"`.

Default value of this parameter is false so no change to default behaviour will occur.