### PR TITLE
Update log-level on SIGHUP

### DIFF
--- a/config.go
+++ b/config.go
@@ -204,6 +204,7 @@ func GetConfigFiles(cfgFile *[]string, cfgFileList string) error {
 // HandleConfigChange to check which config changes are allowed
 func HandleConfigChange(jctx *JCtx, config Config, reload *bool) error {
 	// check verbose log change
+	changed := false
 	if !reflect.DeepEqual(jctx.config, config) {
 		// config changed
 		if !reflect.DeepEqual(jctx.config.Paths, config.Paths) {
@@ -211,12 +212,16 @@ func HandleConfigChange(jctx *JCtx, config Config, reload *bool) error {
 			if reload != nil {
 				*reload = true
 			}
-		} else if jctx.config.Log.Verbose != config.Log.Verbose {
+			changed = true
+		}
+		if jctx.config.Log.Verbose != config.Log.Verbose {
 			if IsVerboseLogging(jctx) {
 				jLog(jctx, fmt.Sprintf("Log level has been changed to %v", config.Log.Verbose))
 			}
 			jctx.config.Log.Verbose = config.Log.Verbose
-		} else {
+			changed = true
+		}
+		if !changed {
 			// Currently only path and log-level changes are allowed. rest will be ignored
 			return fmt.Errorf("ValidateConfigChange: only paths and log-level changes are allowed")
 		}

--- a/config.go
+++ b/config.go
@@ -204,6 +204,13 @@ func GetConfigFiles(cfgFile *[]string, cfgFileList string) error {
 // ValidateConfigChange to check which config changes are allowed
 func ValidateConfigChange(jctx *JCtx, config Config) error {
 	runningCfg := jctx.config
+	// check verbose log change
+	if jctx.config.Log.Verbose != config.Log.Verbose {
+		if IsVerboseLogging(jctx) {
+			jLog(jctx, fmt.Sprintf("Log level has been changed to %v", config.Log.Verbose))
+		}
+		jctx.config.Log.Verbose = config.Log.Verbose
+	}
 	if !reflect.DeepEqual(runningCfg, config) {
 		// config change is now only for path, it can be extended.
 		if !reflect.DeepEqual(runningCfg.Paths, config.Paths) {
@@ -255,6 +262,7 @@ func ConfigRead(jctx *JCtx, init bool) error {
 		go periodicStats(jctx)
 		influxInit(jctx)
 	} else {
+		jLog(jctx, fmt.Sprintf("Config re-read request"))
 		err := ValidateConfigChange(jctx, config)
 		if err == nil {
 			jctx.config.Paths = config.Paths

--- a/config.go
+++ b/config.go
@@ -202,15 +202,15 @@ func GetConfigFiles(cfgFile *[]string, cfgFileList string) error {
 }
 
 // HandleConfigChange to check which config changes are allowed
-func HandleConfigChange(jctx *JCtx, config Config, reload *bool) error {
+func HandleConfigChange(jctx *JCtx, config Config, restart *bool) error {
 	// check verbose log change
 	changed := false
 	if !reflect.DeepEqual(jctx.config, config) {
 		// config changed
 		if !reflect.DeepEqual(jctx.config.Paths, config.Paths) {
 			jctx.config.Paths = config.Paths
-			if reload != nil {
-				*reload = true
+			if restart != nil {
+				*restart = true
 			}
 			changed = true
 		}
@@ -231,7 +231,7 @@ func HandleConfigChange(jctx *JCtx, config Config, reload *bool) error {
 
 // ConfigRead will read the config and init the services.
 // In case of config changes, it will update the existing config
-func ConfigRead(jctx *JCtx, reload *bool) error {
+func ConfigRead(jctx *JCtx, init bool, restart *bool) error {
 	var err error
 
 	config, err := NewJTIMONConfig(jctx.file)
@@ -240,7 +240,7 @@ func ConfigRead(jctx *JCtx, reload *bool) error {
 		return fmt.Errorf("config parsing (json unmarshal) error for %s: %v", jctx.file, err)
 	}
 
-	if reload == nil {
+	if init {
 		jctx.config = config
 		logInit(jctx)
 		b, err := json.MarshalIndent(jctx.config, "", "    ")
@@ -272,7 +272,7 @@ func ConfigRead(jctx *JCtx, reload *bool) error {
 		influxInit(jctx)
 	} else {
 		jLog(jctx, fmt.Sprintf("Config re-read request"))
-		err := HandleConfigChange(jctx, config, reload)
+		err := HandleConfigChange(jctx, config, restart)
 		if err == nil {
 			jLog(jctx, fmt.Sprintf("config has been updated"))
 		} else {

--- a/subscribe_cisco_iosxr_test.go
+++ b/subscribe_cisco_iosxr_test.go
@@ -98,7 +98,7 @@ func TestXRInflux(t *testing.T) {
 			}
 
 			jctx := test.jctx
-			err := ConfigRead(jctx, nil)
+			err := ConfigRead(jctx, true, nil)
 			if err != nil {
 				t.Errorf("error %v for test config %s", err, test.config)
 			}
@@ -217,7 +217,7 @@ func TestXRTagsPoints(t *testing.T) {
 	for _, test := range tt {
 		t.Run(test.name, func(t *testing.T) {
 			jctx := test.jctx
-			err := ConfigRead(jctx, nil)
+			err := ConfigRead(jctx, true, nil)
 			if err != nil {
 				t.Errorf("error %v for test config %s", err, test.config)
 			}

--- a/subscribe_cisco_iosxr_test.go
+++ b/subscribe_cisco_iosxr_test.go
@@ -98,7 +98,7 @@ func TestXRInflux(t *testing.T) {
 			}
 
 			jctx := test.jctx
-			err := ConfigRead(jctx, true)
+			err := ConfigRead(jctx, nil)
 			if err != nil {
 				t.Errorf("error %v for test config %s", err, test.config)
 			}
@@ -217,7 +217,7 @@ func TestXRTagsPoints(t *testing.T) {
 	for _, test := range tt {
 		t.Run(test.name, func(t *testing.T) {
 			jctx := test.jctx
-			err := ConfigRead(jctx, true)
+			err := ConfigRead(jctx, nil)
 			if err != nil {
 				t.Errorf("error %v for test config %s", err, test.config)
 			}

--- a/subscribe_juniper_junos_test.go
+++ b/subscribe_juniper_junos_test.go
@@ -362,7 +362,7 @@ func TestVMXTagsPoints(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			jctx := test.jctx
-			err := ConfigRead(jctx, true)
+			err := ConfigRead(jctx, nil)
 			if err != nil {
 				t.Errorf("error %v for test config %s", err, test.config)
 			}

--- a/subscribe_juniper_junos_test.go
+++ b/subscribe_juniper_junos_test.go
@@ -362,7 +362,7 @@ func TestVMXTagsPoints(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			jctx := test.jctx
-			err := ConfigRead(jctx, nil)
+			err := ConfigRead(jctx, true, nil)
 			if err != nil {
 				t.Errorf("error %v for test config %s", err, test.config)
 			}

--- a/workers.go
+++ b/workers.go
@@ -202,7 +202,7 @@ func NewJWorker(file string, wg *sync.WaitGroup) (*JWorker, error) {
 		testSetup(&jctx)
 	}
 
-	err := ConfigRead(&jctx, nil)
+	err := ConfigRead(&jctx, true, nil)
 	if err != nil {
 		log.Println(err)
 		return w, err
@@ -233,12 +233,12 @@ func NewJWorker(file string, wg *sync.WaitGroup) (*JWorker, error) {
 					// not establihsed and it is trying to connect.
 					// ConfigRead will re-parse the config and updates jctx so
 					// when we retry Dial, it will do it with updated config
-					reload := false
-					err := ConfigRead(&jctx, &reload)
+					restart := false
+					err := ConfigRead(&jctx, false, &restart)
 					if err != nil {
 						jLog(&jctx, fmt.Sprintln(err))
 					} else if jctx.running {
-						if reload {
+						if restart {
 							jctx.control <- syscall.SIGHUP
 							jctx.running = false
 						}

--- a/workers.go
+++ b/workers.go
@@ -202,7 +202,7 @@ func NewJWorker(file string, wg *sync.WaitGroup) (*JWorker, error) {
 		testSetup(&jctx)
 	}
 
-	err := ConfigRead(&jctx, true)
+	err := ConfigRead(&jctx, nil)
 	if err != nil {
 		log.Println(err)
 		return w, err
@@ -233,12 +233,15 @@ func NewJWorker(file string, wg *sync.WaitGroup) (*JWorker, error) {
 					// not establihsed and it is trying to connect.
 					// ConfigRead will re-parse the config and updates jctx so
 					// when we retry Dial, it will do it with updated config
-					err := ConfigRead(&jctx, false)
+					reload := false
+					err := ConfigRead(&jctx, &reload)
 					if err != nil {
 						jLog(&jctx, fmt.Sprintln(err))
 					} else if jctx.running {
-						jctx.control <- syscall.SIGHUP
-						jctx.running = false
+						if reload {
+							jctx.control <- syscall.SIGHUP
+							jctx.running = false
+						}
 					} else {
 						jLog(&jctx, fmt.Sprintf("config re-parse, data streaming has not started yet"))
 					}


### PR DESCRIPTION
Code changes 
  - Log level will be updaed on SIGHUP if it changed
  - Subscriber connections should not be restared if only the log-level is changed

Unit tests 
  - Tested for both log-level and path changes