### PR TITLE
Handle deadlock during SIGHUP handling

### DIFF
--- a/multi_vendor.go
+++ b/multi_vendor.go
@@ -13,7 +13,7 @@ type vendor struct {
 	loginCheckRequired bool
 	sendLoginCheck     func(*JCtx, *grpc.ClientConn) error
 	dialExt            func(*JCtx) grpc.DialOption
-	subscribe          func(*grpc.ClientConn, *JCtx, chan<- bool) SubErrorCode
+	subscribe          func(*grpc.ClientConn, *JCtx) SubErrorCode
 }
 
 func getVendor(jctx *JCtx) (*vendor, error) {

--- a/subscribe_juniper_junos.go
+++ b/subscribe_juniper_junos.go
@@ -99,8 +99,7 @@ func handleOnePacket(ocData *na_pb.OpenConfigData, jctx *JCtx) {
 //			code
 //		- In case of an error, Set the error code to restart the connection.
 func subSendAndReceive(conn *grpc.ClientConn, jctx *JCtx,
-	subReqM na_pb.SubscriptionRequest,
-	statusch chan<- bool) SubErrorCode {
+	subReqM na_pb.SubscriptionRequest) SubErrorCode {
 
 	var ctx context.Context
 	c := na_pb.NewOpenConfigTelemetryClient(conn)
@@ -128,8 +127,6 @@ func subSendAndReceive(conn *grpc.ClientConn, jctx *JCtx,
 
 	datach := make(chan struct{})
 
-	// inform the caller that streaming has been started
-	statusch <- true
 	go func() {
 		// Go Routine which actually starts the streaming connection and receives the data
 		jLog(jctx, fmt.Sprintf("Receiving telemetry data from %s:%d\n", jctx.config.Host, jctx.config.Port))
@@ -206,7 +203,7 @@ func subSendAndReceive(conn *grpc.ClientConn, jctx *JCtx,
 //
 // In case of SIGHUP, the paths are formed again and streaming
 // is restarted.
-func subscribeJunos(conn *grpc.ClientConn, jctx *JCtx, statusch chan<- bool) SubErrorCode {
+func subscribeJunos(conn *grpc.ClientConn, jctx *JCtx) SubErrorCode {
 	var subReqM na_pb.SubscriptionRequest
 	var additionalConfigM na_pb.SubscriptionAdditionalConfig
 
@@ -220,7 +217,7 @@ func subscribeJunos(conn *grpc.ClientConn, jctx *JCtx, statusch chan<- bool) Sub
 	additionalConfigM.NeedEos = jctx.config.EOS
 	subReqM.AdditionalConfig = &additionalConfigM
 
-	return subSendAndReceive(conn, jctx, subReqM, statusch)
+	return subSendAndReceive(conn, jctx, subReqM)
 }
 
 func loginCheckJunos(jctx *JCtx, conn *grpc.ClientConn) error {


### PR DESCRIPTION
Handle deadlock during SIGHUP handling

In the issue reported in https://svl-ssd-git.juniper.net/iceberg/healthbot-jtimon/issues/41 when an erroneous path is configured for a device which is already streaming for a set of paths, following happens:
1. JWorker go-routine(GOR) for the device is SIGHUP'd with this path.
2. JWorker GOR signals it to the control channel on which the subscriber GOR listens
3. Subscriber GOR retries subscription with new path list and closes the old connection. On closing the old connection, the data-stream handling(DST) GOR gets notified at Recv() and hence it terminates.
4. The device returns "Authorization error" for the new path list as there is an erroneous path
5. When the DST GOR gets "Authorization error", it terminates and informs Subscriber GOR via "datach" channel to retry after 10 secs.
6. This keeps on happening
7. Now when the erroneous path is removed from config, JWorker GOR tries to SIGHUP the Subscriber GOR via control channel. If the Subscriber GOR waits for a reply from device during this time, the JWorker GOR  blocks as there is no one to read this signal. Now when the device replies, Subscriber GOR tries to notify "statuschan" to TRUE which needs to be read by JWorker GOR. But then since JWorker GOR is already blocked on writing SIGHUP, Subscriber GOR will also get blocked on writing TRUE. And this leads to a deadlock.

Now, the fix is to remove dependency on "statuschan" for Subscriber GOR.