### PR TITLE
introduce buffersize for granular control

### DIFF
--- a/config.go
+++ b/config.go
@@ -107,6 +107,9 @@ func fillupDefaults(config *Config) {
 	if config.Influx.BatchSize == 0 {
 		config.Influx.BatchSize = DefaultIDBBatchSize
 	}
+	if config.Influx.BufferSize == 0 {
+		config.Influx.BufferSize = DefaultIDBBufferSize
+	}
 	if config.Influx.HTTPTimeout == 0 {
 		config.Influx.HTTPTimeout = DefaultIDBTimeout
 	}

--- a/defaults.go
+++ b/defaults.go
@@ -6,6 +6,8 @@ const (
 
 	// DefaultIDBBatchSize to use if user has not provided in the config
 	DefaultIDBBatchSize = 1024 * 100
+	// DefaultIDBBufferSize to use if user has not provided in the config
+	DefaultIDBBufferSize = 1024
 	//DefaultIDBBatchFreq is 2 seconds
 	DefaultIDBBatchFreq = 2000
 	//DefaultIDBAccumulatorFreq is 2 seconds

--- a/influx.go
+++ b/influx.go
@@ -38,6 +38,7 @@ type InfluxConfig struct {
 	Recreate             bool   `json:"recreate"`
 	Measurement          string `json:"measurement"`
 	BatchSize            int    `json:"batchsize"`
+	BufferSize           int    `json:"buffersize"`
 	BatchFrequency       int    `json:"batchfrequency"`
 	HTTPTimeout          int    `json:"http-timeout"`
 	RetentionPolicy      string `json:"retention-policy"`
@@ -206,12 +207,13 @@ func dbBatchWriteM(jctx *JCtx) {
 	}
 
 	batchSize := jctx.config.Influx.BatchSize
-	batchMCh := make(chan *batchWMData, batchSize/4)
+	bufferSize := jctx.config.Influx.BufferSize
+	batchMCh := make(chan *batchWMData, bufferSize)
 	jctx.influxCtx.batchWMCh = batchMCh
 
 	// wake up periodically and perform batch write into InfluxDB
 	bFreq := jctx.config.Influx.BatchFrequency
-	jLog(jctx, fmt.Sprintln("batch size:", batchSize, "batch frequency:", bFreq))
+	jLog(jctx, fmt.Sprintln("batch size:", batchSize, "batch frequency:", bFreq, "buffer size:", bufferSize))
 
 	ticker := time.NewTicker(time.Duration(bFreq) * time.Millisecond)
 	go func() {


### PR DESCRIPTION
Introduce separate config to control buffer size for influxDB so we don't overload batchSize for both buffer and batch.

Now we have two config params for InfluxDB writes.
1. BufferSize : How many Openconfig JTI packets to hold in memory. If buffer is full, JTIMON won't read from gRPC so it will pass the backpressure to the server producing telemetry data.
2. BatchSize: How many rows to batch together for InfluxDB write. A row is nothing but one or more Influx Points belongs to the same tags.

No change in BatchFrequency params.