### PR TITLE
Bring in new codes from official jtimon

### DIFF
--- a/sample-config/gnmi.json
+++ b/sample-config/gnmi.json
@@ -14,7 +14,8 @@
     "paths": [
         {
             "freq": 30000,
-            "path": "/interfaces/interface/state/"
+            "path": "/interfaces/interface/state/",
+            "origin": "openconfig"
         },
         {
             "freq": 30000,


### PR DESCRIPTION
Bring in new codes from official [jtimon ](https://github.com/Juniper/jtimon).

Please find the `make` output here, which includes unit test results.
$ make 
rm -f jtimon-*
rm -f jtimon
GOOS=linux GOARCH=amd64 go build -mod vendor --ldflags="-X main.jtimonVersion=v2.3.0-7203c8a2d7ad92d05935332390d4b75c63fa2db9-syncup -X main.buildTime=2023-09-07T02:19:21+0530" -o jtimon-linux-amd64 .
GOOS=darwin GOARCH=amd64 go build -mod vendor --ldflags="-X main.jtimonVersion=v2.3.0-7203c8a2d7ad92d05935332390d4b75c63fa2db9-syncup -X main.buildTime=2023-09-07T02:19:22+0530" -o jtimon-darwin-amd64 .
go vet
go test --covermode=count -v --coverprofile=coverage.out
TestMain - waiting 3s for JTISIM and Influx Store to come up
TestMain - done waiting
=== RUN   TestNewAlias
=== RUN   TestNewAlias/invalid-file
=== RUN   TestNewAlias/valid-file-syntax_error
=== RUN   TestNewAlias/valid-file
--- PASS: TestNewAlias (0.00s)
    --- PASS: TestNewAlias/invalid-file (0.00s)
    --- PASS: TestNewAlias/valid-file-syntax_error (0.00s)
    --- PASS: TestNewAlias/valid-file (0.00s)
=== RUN   TestNewJTIMONConfig
=== RUN   TestNewJTIMONConfig/tests/data/noerror.json
=== RUN   TestNewJTIMONConfig/tests/data/error.jso
=== RUN   TestNewJTIMONConfig/tests/data/error.json
--- PASS: TestNewJTIMONConfig (0.00s)
    --- PASS: TestNewJTIMONConfig/tests/data/noerror.json (0.00s)
    --- PASS: TestNewJTIMONConfig/tests/data/error.jso (0.00s)
    --- PASS: TestNewJTIMONConfig/tests/data/error.json (0.00s)
=== RUN   TestNewJTIMONConfigFilelist
=== RUN   TestNewJTIMONConfigFilelist/tests/data/file_list.json
=== RUN   TestNewJTIMONConfigFilelist/tests/data/file_list.jso
=== RUN   TestNewJTIMONConfigFilelist/tests/data/file_list_err.json
--- PASS: TestNewJTIMONConfigFilelist (0.00s)
    --- PASS: TestNewJTIMONConfigFilelist/tests/data/file_list.json (0.00s)
    --- PASS: TestNewJTIMONConfigFilelist/tests/data/file_list.jso (0.00s)
    --- PASS: TestNewJTIMONConfigFilelist/tests/data/file_list_err.json (0.00s)
=== RUN   TestValidateConfig
=== RUN   TestValidateConfig/tests/data/noerror.json
=== RUN   TestValidateConfig/tests/data/error.jso
=== RUN   TestValidateConfig/tests/data/error.json
--- PASS: TestValidateConfig (0.00s)
    --- PASS: TestValidateConfig/tests/data/noerror.json (0.00s)
    --- PASS: TestValidateConfig/tests/data/error.jso (0.00s)
    --- PASS: TestValidateConfig/tests/data/error.json (0.00s)
=== RUN   TestExploreConfig
=== RUN   TestExploreConfig/explore-config
--- PASS: TestExploreConfig (0.00s)
    --- PASS: TestExploreConfig/explore-config (0.00s)
=== RUN   TestStringInSlice
=== RUN   TestStringInSlice/first
=== RUN   TestStringInSlice/two
=== RUN   TestStringInSlice/third
--- PASS: TestStringInSlice (0.00s)
    --- PASS: TestStringInSlice/first (0.00s)
    --- PASS: TestStringInSlice/two (0.00s)
    --- PASS: TestStringInSlice/third (0.00s)
=== RUN   TestXPathTognmiPath
=== RUN   TestXPathTognmiPath/multi-level-multi-keys
=== RUN   TestXPathTognmiPath/multi-level-multi-keys-err
=== RUN   TestXPathTognmiPath/multi-level-multi-keys-xpath-err
--- PASS: TestXPathTognmiPath (0.00s)
    --- PASS: TestXPathTognmiPath/multi-level-multi-keys (0.00s)
    --- PASS: TestXPathTognmiPath/multi-level-multi-keys-err (0.00s)
    --- PASS: TestXPathTognmiPath/multi-level-multi-keys-xpath-err (0.00s)
=== RUN   TestGnmiMode
=== RUN   TestGnmiMode/gnmi-mode-on-change
=== RUN   TestGnmiMode/gnmi-mode-sample
=== RUN   TestGnmiMode/gnmi-mode-err
--- PASS: TestGnmiMode (0.00s)
    --- PASS: TestGnmiMode/gnmi-mode-on-change (0.00s)
    --- PASS: TestGnmiMode/gnmi-mode-sample (0.00s)
    --- PASS: TestGnmiMode/gnmi-mode-err (0.00s)
=== RUN   TestGnmiFreq
=== RUN   TestGnmiFreq/gnmi-freq-sample
=== RUN   TestGnmiFreq/gnmi-freq-on-change
=== RUN   TestGnmiFreq/gnmi-freq-sample-taken-as-on-change
=== RUN   TestGnmiFreq/gnmi-freq-target-defined
=== RUN   TestGnmiFreq/gnmi-freq-sample-err
--- PASS: TestGnmiFreq (0.00s)
    --- PASS: TestGnmiFreq/gnmi-freq-sample (0.00s)
    --- PASS: TestGnmiFreq/gnmi-freq-on-change (0.00s)
    --- PASS: TestGnmiFreq/gnmi-freq-sample-taken-as-on-change (0.00s)
    --- PASS: TestGnmiFreq/gnmi-freq-target-defined (0.00s)
    --- PASS: TestGnmiFreq/gnmi-freq-sample-err (0.00s)
=== RUN   TestGnmiParseUpdates
=== RUN   TestGnmiParseUpdates/updates-valid-no-prefix
=== RUN   TestGnmiParseUpdates/updates-valid-with-prefix
=== RUN   TestGnmiParseUpdates/updates-valid-with-misc-simple-types
=== RUN   TestGnmiParseUpdates/updates-valid-scalar-array
=== RUN   TestGnmiParseUpdates/updates-valid-with-misc-simple-types-json
=== RUN   TestGnmiParseUpdates/updates-valid-with-misc-simple-types-json_ietf
=== RUN   TestGnmiParseUpdates/updates-valid-no-prefix-with-origin--config--donotParseOrigin
=== RUN   TestGnmiParseUpdates/updates-valid-no-prefix-with-origin--config--parseOrigin
=== RUN   TestGnmiParseUpdates/updates-valid-with-misc-simple-types-uint-enabled
--- PASS: TestGnmiParseUpdates (0.00s)
    --- PASS: TestGnmiParseUpdates/updates-valid-no-prefix (0.00s)
    --- PASS: TestGnmiParseUpdates/updates-valid-with-prefix (0.00s)
    --- PASS: TestGnmiParseUpdates/updates-valid-with-misc-simple-types (0.00s)
    --- PASS: TestGnmiParseUpdates/updates-valid-scalar-array (0.00s)
    --- PASS: TestGnmiParseUpdates/updates-valid-with-misc-simple-types-json (0.00s)
    --- PASS: TestGnmiParseUpdates/updates-valid-with-misc-simple-types-json_ietf (0.00s)
    --- PASS: TestGnmiParseUpdates/updates-valid-no-prefix-with-origin--config--donotParseOrigin (0.00s)
    --- PASS: TestGnmiParseUpdates/updates-valid-no-prefix-with-origin--config--parseOrigin (0.00s)
    --- PASS: TestGnmiParseUpdates/updates-valid-with-misc-simple-types-uint-enabled (0.00s)
=== RUN   TestGnmiParseDeletes
=== RUN   TestGnmiParseDeletes/deletes-valid-no-prefix
=== RUN   TestGnmiParseDeletes/deletes-valid-no-prefix-with-origin
--- PASS: TestGnmiParseDeletes (0.00s)
    --- PASS: TestGnmiParseDeletes/deletes-valid-no-prefix (0.00s)
    --- PASS: TestGnmiParseDeletes/deletes-valid-no-prefix-with-origin (0.00s)
=== RUN   TestFormJuniperTelemetryHdr
=== RUN   TestFormJuniperTelemetryHdr/juniper-gnmi-header-in-updates-parsed-as-xpaths
=== RUN   TestFormJuniperTelemetryHdr/juniper-gnmi-header-in-extension
=== RUN   TestFormJuniperTelemetryHdr/other-vendor
--- PASS: TestFormJuniperTelemetryHdr (0.00s)
    --- PASS: TestFormJuniperTelemetryHdr/juniper-gnmi-header-in-updates-parsed-as-xpaths (0.00s)
    --- PASS: TestFormJuniperTelemetryHdr/juniper-gnmi-header-in-extension (0.00s)
    --- PASS: TestFormJuniperTelemetryHdr/other-vendor (0.00s)
=== RUN   TestGnmiParsePath
--- PASS: TestGnmiParsePath (0.00s)
=== RUN   TestGnmiParseValue
--- PASS: TestGnmiParseValue (0.00s)
=== RUN   TestSpitTagsNPath
=== RUN   TestSpitTagsNPath/path-without-tags
=== RUN   TestSpitTagsNPath/ifd-admin-status
=== RUN   TestSpitTagsNPath/ifl-admin-status
=== RUN   TestSpitTagsNPath/cmerror
=== RUN   TestSpitTagsNPath/events
=== RUN   TestSpitTagsNPath/events-2
--- PASS: TestSpitTagsNPath (0.00s)
    --- PASS: TestSpitTagsNPath/path-without-tags (0.00s)
    --- PASS: TestSpitTagsNPath/ifd-admin-status (0.00s)
    --- PASS: TestSpitTagsNPath/ifl-admin-status (0.00s)
    --- PASS: TestSpitTagsNPath/cmerror (0.00s)
    --- PASS: TestSpitTagsNPath/events (0.00s)
    --- PASS: TestSpitTagsNPath/events-2 (0.00s)
=== RUN   TestSubscriptionPathFromPath
--- PASS: TestSubscriptionPathFromPath (0.00s)
=== RUN   TestCheckAndCeilFloatValues
=== RUN   TestCheckAndCeilFloatValues/PracticalMaxLowerBoun
=== RUN   TestCheckAndCeilFloatValues/PracticalMaxUpperBound
=== RUN   TestCheckAndCeilFloatValues/PracticalNonMax
=== RUN   TestCheckAndCeilFloatValues/Float32
=== RUN   TestCheckAndCeilFloatValues/negInf64PracticalMaxLowerBound
=== RUN   TestCheckAndCeilFloatValues/negInf64PracticalMaxUpperBound
=== RUN   TestCheckAndCeilFloatValues/PracticalNonMin
=== RUN   TestCheckAndCeilFloatValues/Float32Min
=== RUN   TestCheckAndCeilFloatValues/Zero32
=== RUN   TestCheckAndCeilFloatValues/Zero64
--- PASS: TestCheckAndCeilFloatValues (0.00s)
    --- PASS: TestCheckAndCeilFloatValues/PracticalMaxLowerBoun (0.00s)
    --- PASS: TestCheckAndCeilFloatValues/PracticalMaxUpperBound (0.00s)
    --- PASS: TestCheckAndCeilFloatValues/PracticalNonMax (0.00s)
    --- PASS: TestCheckAndCeilFloatValues/Float32 (0.00s)
    --- PASS: TestCheckAndCeilFloatValues/negInf64PracticalMaxLowerBound (0.00s)
    --- PASS: TestCheckAndCeilFloatValues/negInf64PracticalMaxUpperBound (0.00s)
    --- PASS: TestCheckAndCeilFloatValues/PracticalNonMin (0.00s)
    --- PASS: TestCheckAndCeilFloatValues/Float32Min (0.00s)
    --- PASS: TestCheckAndCeilFloatValues/Zero32 (0.00s)
    --- PASS: TestCheckAndCeilFloatValues/Zero64 (0.00s)
=== RUN   TestTransformPath
=== RUN   TestTransformPath/noenv1
=== RUN   TestTransformPath/env1
=== RUN   TestTransformPath/noenv2
=== RUN   TestTransformPath/env2
=== RUN   TestTransformPath/env3
--- PASS: TestTransformPath (0.00s)
    --- PASS: TestTransformPath/noenv1 (0.00s)
    --- PASS: TestTransformPath/env1 (0.00s)
    --- PASS: TestTransformPath/noenv2 (0.00s)
    --- PASS: TestTransformPath/env2 (0.00s)
    --- PASS: TestTransformPath/env3 (0.00s)
=== RUN   TestXRInflux
=== RUN   TestXRInflux/xr-all
2023/09/07 02:19:34 open: tests/data/cisco-ios-xr/config/xr-all-influx.json.testres
2023/09/07 02:19:34 logging in tests/data/cisco-ios-xr/config/xr-all-influx.log for 172.27.113.191:32767 [periodic stats every 0 seconds]
name: tests/data/cisco-ios-xr/schema/
2023/09/07 02:19:46 close: tests/data/cisco-ios-xr/config/xr-all-influx.json.testres
=== RUN   TestXRInflux/xr-wdsysmon
2023/09/07 02:19:46 open: tests/data/cisco-ios-xr/config/xr-wdsysmon-influx.json.testres
2023/09/07 02:19:46 logging in tests/data/cisco-ios-xr/config/xr-wdsysmon-influx.log for 172.27.113.191:32767 [periodic stats every 0 seconds]
name: tests/data/cisco-ios-xr/schema/
2023/09/07 02:19:54 close: tests/data/cisco-ios-xr/config/xr-wdsysmon-influx.json.testres
--- PASS: TestXRInflux (20.10s)
    --- PASS: TestXRInflux/xr-all (12.08s)
    --- PASS: TestXRInflux/xr-wdsysmon (8.02s)
=== RUN   TestXRTagsPoints
=== RUN   TestXRTagsPoints/xr-all
name: tests/data/cisco-ios-xr/schema/
=== RUN   TestXRTagsPoints/xr-wdsysmon
name: tests/data/cisco-ios-xr/schema/
--- PASS: TestXRTagsPoints (0.36s)
    --- PASS: TestXRTagsPoints/xr-all (0.26s)
    --- PASS: TestXRTagsPoints/xr-wdsysmon (0.09s)
=== RUN   TestXRSchema
=== RUN   TestXRSchema/directory
name: tests/data/cisco-ios-xr/schema
=== RUN   TestXRSchema/file
name: tests/data/cisco-ios-xr/schema/interfaces.json
=== RUN   TestXRSchema/env
envPath: tests/data/cisco-ios-xr/schema/interfaces.json
--- PASS: TestXRSchema (0.00s)
    --- PASS: TestXRSchema/directory (0.00s)
    --- PASS: TestXRSchema/file (0.00s)
    --- PASS: TestXRSchema/env (0.00s)
=== RUN   Test_getFieldValueInterface
=== RUN   Test_getFieldValueInterface/unsigned-data-and-uint-enabled
=== RUN   Test_getFieldValueInterface/unsigned-data-and-uint-disabled
=== RUN   Test_getFieldValueInterface/string
=== RUN   Test_getFieldValueInterface/uint32
=== RUN   Test_getFieldValueInterface/sint32
=== RUN   Test_getFieldValueInterface/sint64
=== RUN   Test_getFieldValueInterface/double
=== RUN   Test_getFieldValueInterface/bool
=== RUN   Test_getFieldValueInterface/bytes
=== RUN   Test_getFieldValueInterface/default
--- PASS: Test_getFieldValueInterface (0.00s)
    --- PASS: Test_getFieldValueInterface/unsigned-data-and-uint-enabled (0.00s)
    --- PASS: Test_getFieldValueInterface/unsigned-data-and-uint-disabled (0.00s)
    --- PASS: Test_getFieldValueInterface/string (0.00s)
    --- PASS: Test_getFieldValueInterface/uint32 (0.00s)
    --- PASS: Test_getFieldValueInterface/sint32 (0.00s)
    --- PASS: Test_getFieldValueInterface/sint64 (0.00s)
    --- PASS: Test_getFieldValueInterface/double (0.00s)
    --- PASS: Test_getFieldValueInterface/bool (0.00s)
    --- PASS: Test_getFieldValueInterface/bytes (0.00s)
    --- PASS: Test_getFieldValueInterface/default (0.00s)
=== RUN   TestConvToFloatForPrometheus
=== RUN   TestConvToFloatForPrometheus/int
=== RUN   TestConvToFloatForPrometheus/uint
=== RUN   TestConvToFloatForPrometheus/int64
=== RUN   TestConvToFloatForPrometheus/bool
=== RUN   TestConvToFloatForPrometheus/string
=== RUN   TestConvToFloatForPrometheus/string-err
--- PASS: TestConvToFloatForPrometheus (0.00s)
    --- PASS: TestConvToFloatForPrometheus/int (0.00s)
    --- PASS: TestConvToFloatForPrometheus/uint (0.00s)
    --- PASS: TestConvToFloatForPrometheus/int64 (0.00s)
    --- PASS: TestConvToFloatForPrometheus/bool (0.00s)
    --- PASS: TestConvToFloatForPrometheus/string (0.00s)
    --- PASS: TestConvToFloatForPrometheus/string-err (0.00s)
=== RUN   TestGnmiHandleResponse
=== RUN   TestGnmiHandleResponse/rsp-valid-sync
=== RUN   TestGnmiHandleResponse/rsp-valid-updates
=== RUN   TestGnmiHandleResponse/rsp-valid-deletes
=== RUN   TestGnmiHandleResponse/rsp-check-not-expecting-eos-juniper-isync-packet-ext
=== RUN   TestGnmiHandleResponse/rsp-check-not-expecting-eos-juniper-isync-packet-xpath
=== RUN   TestGnmiHandleResponse/rsp-valid-sync-ipv6
=== RUN   TestGnmiHandleResponse/rsp-valid-updates-ipv6
=== RUN   TestGnmiHandleResponse/rsp-valid-deletes-ipv6
=== RUN   TestGnmiHandleResponse/rsp-check-not-expecting-eos-juniper-isync-packet-ext-ipv6
=== RUN   TestGnmiHandleResponse/rsp-check-not-expecting-eos-juniper-isync-packet-xpath-ipv6
--- PASS: TestGnmiHandleResponse (0.00s)
    --- PASS: TestGnmiHandleResponse/rsp-valid-sync (0.00s)
    --- PASS: TestGnmiHandleResponse/rsp-valid-updates (0.00s)
    --- PASS: TestGnmiHandleResponse/rsp-valid-deletes (0.00s)
    --- PASS: TestGnmiHandleResponse/rsp-check-not-expecting-eos-juniper-isync-packet-ext (0.00s)
    --- PASS: TestGnmiHandleResponse/rsp-check-not-expecting-eos-juniper-isync-packet-xpath (0.00s)
    --- PASS: TestGnmiHandleResponse/rsp-valid-sync-ipv6 (0.00s)
    --- PASS: TestGnmiHandleResponse/rsp-valid-updates-ipv6 (0.00s)
    --- PASS: TestGnmiHandleResponse/rsp-valid-deletes-ipv6 (0.00s)
    --- PASS: TestGnmiHandleResponse/rsp-check-not-expecting-eos-juniper-isync-packet-ext-ipv6 (0.00s)
    --- PASS: TestGnmiHandleResponse/rsp-check-not-expecting-eos-juniper-isync-packet-xpath-ipv6 (0.00s)
=== RUN   TestSubscribegNMI
--- PASS: TestSubscribegNMI (0.00s)
=== RUN   TestPublishToPrometheus
--- PASS: TestPublishToPrometheus (0.00s)
=== RUN   TestPublishToInflux
--- PASS: TestPublishToInflux (0.00s)
=== RUN   TestGnmiParseHeader
--- PASS: TestGnmiParseHeader (0.00s)
=== RUN   TestGnmiParseNotification
--- PASS: TestGnmiParseNotification (0.00s)
=== RUN   TestJTISIMSigHup
2023/09/07 02:19:55 logging in tests/data/juniper-junos/config/jtisim-interfaces-1.log for 127.0.0.1:50051 [periodic stats every 2 seconds]
2023/09/07 02:19:55 127.0.0.1, jctx.config.Kafka.producer: <nil>
2023/09/07 02:19:55 logging in tests/data/juniper-junos/config/jtisim-interfaces-2.log for 127.0.0.1:50051 [periodic stats every 2 seconds]
2023/09/07 02:19:55 127.0.0.1, jctx.config.Kafka.producer: <nil>
2023/09/07 02:19:55 logging in tests/data/juniper-junos/config/jtisim-interfaces-3.log for 127.0.0.1:50051 [periodic stats every 2 seconds]
2023/09/07 02:19:55 127.0.0.1, jctx.config.Kafka.producer: <nil>
Calling subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-3.json
Calling subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-2.json
Calling subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-1.json
2023/09/07 02:19:55 Client metadata:
2023/09/07 02:19:55 map[:authority:[127.0.0.1:50051] content-type:[application/grpc] grpc-accept-encoding:[gzip] user-agent:[grpc-go/1.53.0]]
2023/09/07 02:19:55 Client metadata:
2023/09/07 02:19:55 map[:authority:[127.0.0.1:50051] content-type:[application/grpc] grpc-accept-encoding:[gzip] user-agent:[grpc-go/1.53.0]]
2023/09/07 02:19:55 Client metadata:
2023/09/07 02:19:55 map[:authority:[127.0.0.1:50051] content-type:[application/grpc] grpc-accept-encoding:[gzip] user-agent:[grpc-go/1.53.0]]
2023/09/07 02:19:55 /interfaces 10000
2023/09/07 02:19:55 /interfaces 10000
2023/09/07 02:19:55 /interfaces 10000
[1] -----  tests/data/juniper-junos/config/jtisim-interfaces-1.json 40
[1] -----  tests/data/juniper-junos/config/jtisim-interfaces-2.json 40
[1] -----  tests/data/juniper-junos/config/jtisim-interfaces-3.json 40
2023/09/07 02:19:59 sending sighup to the worker for tests/data/juniper-junos/config/jtisim-interfaces-3.json
2023/09/07 02:19:59 deleting worker for tests/data/juniper-junos/config/jtisim-interfaces-1.json
2023/09/07 02:19:59 deleting worker for tests/data/juniper-junos/config/jtisim-interfaces-2.json
Returns subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-2.json CODE :::  2
Returns subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-1.json CODE :::  2
[2] -----  tests/data/juniper-junos/config/jtisim-interfaces-3.json 40
2023/09/07 02:20:05 adding a new worker for tests/data/juniper-junos/config/jtisim-interfaces-1.json
2023/09/07 02:20:05 logging in tests/data/juniper-junos/config/jtisim-interfaces-1.log for 127.0.0.1:50051 [periodic stats every 2 seconds]
2023/09/07 02:20:05 127.0.0.1, jctx.config.Kafka.producer: <nil>
2023/09/07 02:20:05 adding a new worker for tests/data/juniper-junos/config/jtisim-interfaces-2.json
Calling subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-1.json
2023/09/07 02:20:05 logging in tests/data/juniper-junos/config/jtisim-interfaces-2.log for 127.0.0.1:50051 [periodic stats every 2 seconds]
2023/09/07 02:20:05 127.0.0.1, jctx.config.Kafka.producer: <nil>
Calling subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-2.json
2023/09/07 02:20:05 Client metadata:
2023/09/07 02:20:05 map[:authority:[127.0.0.1:50051] content-type:[application/grpc] grpc-accept-encoding:[gzip] user-agent:[grpc-go/1.53.0]]
2023/09/07 02:20:05 /interfaces 10000
2023/09/07 02:20:05 sending sighup to the worker for tests/data/juniper-junos/config/jtisim-interfaces-3.json
2023/09/07 02:20:05 Client metadata:
2023/09/07 02:20:05 map[:authority:[127.0.0.1:50051] content-type:[application/grpc] grpc-accept-encoding:[gzip] user-agent:[grpc-go/1.53.0]]
2023/09/07 02:20:05 /interfaces 10000
Returns subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-3.json CODE :::  2
Returns subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-1.json CODE :::  2
--- PASS: TestJTISIMSigHup (14.00s)
=== RUN   TestJTISIMSigHupChanged
Returns subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-2.json CODE :::  2
2023/09/07 02:20:09 logging in tests/data/juniper-junos/config/jtisim-interfaces-1.log for 127.0.0.1:50051 [periodic stats every 2 seconds]
2023/09/07 02:20:09 127.0.0.1, jctx.config.Kafka.producer: <nil>
2023/09/07 02:20:09 logging in tests/data/juniper-junos/config/jtisim-interfaces-2.log for 127.0.0.1:50051 [periodic stats every 2 seconds]
2023/09/07 02:20:09 127.0.0.1, jctx.config.Kafka.producer: <nil>
2023/09/07 02:20:09 logging in tests/data/juniper-junos/config/jtisim-interfaces-3.log for 127.0.0.1:50051 [periodic stats every 2 seconds]
2023/09/07 02:20:09 127.0.0.1, jctx.config.Kafka.producer: <nil>
Calling subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-3.json
Calling subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-1.json
Calling subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-2.json
2023/09/07 02:20:09 Client metadata:
2023/09/07 02:20:09 map[:authority:[127.0.0.1:50051] content-type:[application/grpc] grpc-accept-encoding:[gzip] user-agent:[grpc-go/1.53.0]]
2023/09/07 02:20:09 /interfaces 10000
2023/09/07 02:20:09 Client metadata:
2023/09/07 02:20:09 map[:authority:[127.0.0.1:50051] content-type:[application/grpc] grpc-accept-encoding:[gzip] user-agent:[grpc-go/1.53.0]]
2023/09/07 02:20:09 /interfaces 10000
2023/09/07 02:20:09 Client metadata:
2023/09/07 02:20:09 map[:authority:[127.0.0.1:50051] content-type:[application/grpc] grpc-accept-encoding:[gzip] user-agent:[grpc-go/1.53.0]]
2023/09/07 02:20:09 /interfaces 10000
[1] -----  tests/data/juniper-junos/config/jtisim-interfaces-1.json 40
[1] -----  tests/data/juniper-junos/config/jtisim-interfaces-2.json 40
[1] -----  tests/data/juniper-junos/config/jtisim-interfaces-3.json 40
2023/09/07 02:20:13 sending sighup to the worker for tests/data/juniper-junos/config/jtisim-interfaces-3.json
2023/09/07 02:20:13 deleting worker for tests/data/juniper-junos/config/jtisim-interfaces-1.json
2023/09/07 02:20:13 deleting worker for tests/data/juniper-junos/config/jtisim-interfaces-2.json
Returns subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-2.json CODE :::  2
Returns subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-1.json CODE :::  2
[2] -----  tests/data/juniper-junos/config/jtisim-interfaces-3.json 40
2023/09/07 02:20:19 adding a new worker for tests/data/juniper-junos/config/jtisim-interfaces-1.json
2023/09/07 02:20:19 logging in tests/data/juniper-junos/config/jtisim-interfaces-1.log for 127.0.0.1:50051 [periodic stats every 2 seconds]
2023/09/07 02:20:19 127.0.0.1, jctx.config.Kafka.producer: <nil>
2023/09/07 02:20:19 adding a new worker for tests/data/juniper-junos/config/jtisim-interfaces-2.json
Calling subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-1.json
2023/09/07 02:20:19 logging in tests/data/juniper-junos/config/jtisim-interfaces-2.log for 127.0.0.1:50051 [periodic stats every 2 seconds]
2023/09/07 02:20:19 127.0.0.1, jctx.config.Kafka.producer: <nil>
Calling subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-2.json
2023/09/07 02:20:19 adding a new worker for tests/data/juniper-junos/config/jtisim-interfaces-6.json
2023/09/07 02:20:19 logging in tests/data/juniper-junos/config/jtisim-interfaces-6.log for 127.0.0.1:50051 [periodic stats every 2 seconds]
2023/09/07 02:20:19 127.0.0.1, jctx.config.Kafka.producer: <nil>
Calling subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-6.json
2023/09/07 02:20:19 deleting worker for tests/data/juniper-junos/config/jtisim-interfaces-3.json
Returns subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-3.json CODE :::  2
2023/09/07 02:20:19 Client metadata:
2023/09/07 02:20:19 Client metadata:
2023/09/07 02:20:19 map[:authority:[127.0.0.1:50051] content-type:[application/grpc] grpc-accept-encoding:[gzip] user-agent:[grpc-go/1.53.0]]
2023/09/07 02:20:19 Client metadata:
2023/09/07 02:20:19 map[:authority:[127.0.0.1:50051] content-type:[application/grpc] grpc-accept-encoding:[gzip] user-agent:[grpc-go/1.53.0]]
2023/09/07 02:20:19 /interfaces 10000
2023/09/07 02:20:19 /interfaces 10000
2023/09/07 02:20:19 map[:authority:[127.0.0.1:50051] content-type:[application/grpc] grpc-accept-encoding:[gzip] user-agent:[grpc-go/1.53.0]]
2023/09/07 02:20:19 /interfaces 20000
Returns subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-6.json CODE :::  2
Returns subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-1.json CODE :::  2
--- PASS: TestJTISIMSigHupChanged (14.00s)
=== RUN   TestJTISIMSigInt
Returns subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-2.json CODE :::  2
2023/09/07 02:20:23 logging in tests/data/juniper-junos/config/jtisim-interfaces-1.log for 127.0.0.1:50051 [periodic stats every 2 seconds]
2023/09/07 02:20:23 127.0.0.1, jctx.config.Kafka.producer: <nil>
2023/09/07 02:20:23 logging in tests/data/juniper-junos/config/jtisim-interfaces-2.log for 127.0.0.1:50051 [periodic stats every 2 seconds]
2023/09/07 02:20:23 127.0.0.1, jctx.config.Kafka.producer: <nil>
2023/09/07 02:20:23 logging in tests/data/juniper-junos/config/jtisim-interfaces-3.log for 127.0.0.1:50051 [periodic stats every 2 seconds]
2023/09/07 02:20:23 127.0.0.1, jctx.config.Kafka.producer: <nil>
Calling subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-2.json
Calling subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-3.json
Calling subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-1.json
2023/09/07 02:20:23 Client metadata:
2023/09/07 02:20:23 Client metadata:
2023/09/07 02:20:23 map[:authority:[127.0.0.1:50051] content-type:[application/grpc] grpc-accept-encoding:[gzip] user-agent:[grpc-go/1.53.0]]
2023/09/07 02:20:23 /interfaces 10000
2023/09/07 02:20:23 map[:authority:[127.0.0.1:50051] content-type:[application/grpc] grpc-accept-encoding:[gzip] user-agent:[grpc-go/1.53.0]]
2023/09/07 02:20:23 /interfaces 10000
2023/09/07 02:20:23 Client metadata:
2023/09/07 02:20:23 map[:authority:[127.0.0.1:50051] content-type:[application/grpc] grpc-accept-encoding:[gzip] user-agent:[grpc-go/1.53.0]]
2023/09/07 02:20:23 /interfaces 10000
Returns subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-1.json CODE :::  2
Returns subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-2.json CODE :::  2
Returns subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-3.json CODE :::  2
--- PASS: TestJTISIMSigInt (15.00s)
=== RUN   TestJTISIMRetrySigInt
2023/09/07 02:20:38 logging in tests/data/juniper-junos/config/jtisim-interfaces-4.log for 127.0.0.1:90052 [periodic stats every 0 seconds]
2023/09/07 02:20:38 127.0.0.1, jctx.config.Kafka.producer: <nil>
Calling subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-4.json
Returns subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-4.json CODE :::  0
Calling subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-4.json
Returns subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-4.json CODE :::  0
--- PASS: TestJTISIMRetrySigInt (25.00s)
=== RUN   TestPrometheus
=== RUN   TestPrometheus/influx-1
2023/09/07 02:21:03 logging in tests/data/juniper-junos/config/jtisim-prometheus.log for 127.0.0.1:50051 [periodic stats every 2 seconds]
2023/09/07 02:21:03 127.0.0.1, jctx.config.Kafka.producer: <nil>
Calling subscribe() ::: tests/data/juniper-junos/config/jtisim-prometheus.json
2023/09/07 02:21:03 Client metadata:
2023/09/07 02:21:03 map[:authority:[127.0.0.1:50051] content-type:[application/grpc] grpc-accept-encoding:[gzip] user-agent:[grpc-go/1.53.0]]
2023/09/07 02:21:03 /interfaces 20000
Returns subscribe() ::: tests/data/juniper-junos/config/jtisim-prometheus.json CODE :::  2
--- PASS: TestPrometheus (6.03s)
    --- PASS: TestPrometheus/influx-1 (6.03s)
=== RUN   TestInflux
=== RUN   TestInflux/influx-1
2023/09/07 02:21:09 open: tests/data/juniper-junos/config/jtisim-influx.json.testres
2023/09/07 02:21:09 logging in tests/data/juniper-junos/config/jtisim-influx.log for 127.0.0.1:50051 [periodic stats every 2 seconds]
2023/09/07 02:21:09 127.0.0.1, jctx.config.Kafka.producer: <nil>
Calling subscribe() ::: tests/data/juniper-junos/config/jtisim-influx.json
2023/09/07 02:21:09 Client metadata:
2023/09/07 02:21:09 map[:authority:[127.0.0.1:50051] content-type:[application/grpc] grpc-accept-encoding:[gzip] user-agent:[grpc-go/1.53.0]]
2023/09/07 02:21:09 /interfaces 10000
Returns subscribe() ::: tests/data/juniper-junos/config/jtisim-influx.json CODE :::  2
2023/09/07 02:21:34 close: tests/data/juniper-junos/config/jtisim-influx.json.testres
=== RUN   TestInflux/influx-alias
2023/09/07 02:21:34 open: tests/data/juniper-junos/config/jtisim-influx-alias.json.testres
2023/09/07 02:21:34 logging in tests/data/juniper-junos/config/jtisim-influx-alias.log for 127.0.0.1:50051 [periodic stats every 2 seconds]
2023/09/07 02:21:34 127.0.0.1, jctx.config.Kafka.producer: <nil>
Calling subscribe() ::: tests/data/juniper-junos/config/jtisim-influx-alias.json
2023/09/07 02:21:34 Client metadata:
2023/09/07 02:21:34 map[:authority:[127.0.0.1:50051] content-type:[application/grpc] grpc-accept-encoding:[gzip] user-agent:[grpc-go/1.53.0]]
2023/09/07 02:21:34 /interfaces 10000
Returns subscribe() ::: tests/data/juniper-junos/config/jtisim-influx-alias.json CODE :::  2
2023/09/07 02:21:42 close: tests/data/juniper-junos/config/jtisim-influx-alias.json.testres
--- PASS: TestInflux (33.01s)
    --- PASS: TestInflux/influx-1 (25.01s)
    --- PASS: TestInflux/influx-alias (8.01s)
=== RUN   TestJTISIMMaxRun
=== RUN   TestJTISIMMaxRun/multi-file-list-1gzip
2023/09/07 02:21:42 logging in tests/data/juniper-junos/config/jtisim-interfaces-1.log for 127.0.0.1:50051 [periodic stats every 2 seconds]
2023/09/07 02:21:42 127.0.0.1, jctx.config.Kafka.producer: <nil>
2023/09/07 02:21:42 logging in tests/data/juniper-junos/config/jtisim-interfaces-2.log for 127.0.0.1:50051 [periodic stats every 2 seconds]
2023/09/07 02:21:42 127.0.0.1, jctx.config.Kafka.producer: <nil>
Calling subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-1.json
Calling subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-2.json
2023/09/07 02:21:42 Client metadata:
2023/09/07 02:21:42 map[:authority:[127.0.0.1:50051] content-type:[application/grpc] grpc-accept-encoding:[gzip] user-agent:[grpc-go/1.53.0]]
2023/09/07 02:21:42 /interfaces 10000
2023/09/07 02:21:42 Client metadata:
2023/09/07 02:21:42 map[:authority:[127.0.0.1:50051] content-type:[application/grpc] grpc-accept-encoding:[gzip] user-agent:[grpc-go/1.53.0]]
2023/09/07 02:21:42 /interfaces 10000
=== RUN   TestJTISIMMaxRun/multi-file-list-1
Returns subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-2.json CODE :::  2
Returns subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-1.json CODE :::  2
2023/09/07 02:22:07 logging in tests/data/juniper-junos/config/jtisim-interfaces-1.log for 127.0.0.1:50051 [periodic stats every 2 seconds]
2023/09/07 02:22:07 127.0.0.1, jctx.config.Kafka.producer: <nil>
2023/09/07 02:22:07 logging in tests/data/juniper-junos/config/jtisim-interfaces-2.log for 127.0.0.1:50051 [periodic stats every 2 seconds]
2023/09/07 02:22:07 127.0.0.1, jctx.config.Kafka.producer: <nil>
Calling subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-1.json
Calling subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-2.json
2023/09/07 02:22:07 Client metadata:
2023/09/07 02:22:07 map[:authority:[127.0.0.1:50051] content-type:[application/grpc] grpc-accept-encoding:[gzip] user-agent:[grpc-go/1.53.0]]
2023/09/07 02:22:07 /interfaces 10000
2023/09/07 02:22:07 Client metadata:
2023/09/07 02:22:07 map[:authority:[127.0.0.1:50051] content-type:[application/grpc] grpc-accept-encoding:[gzip] user-agent:[grpc-go/1.53.0]]
2023/09/07 02:22:07 /interfaces 10000
Returns subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-1.json CODE :::  2
Returns subscribe() ::: tests/data/juniper-junos/config/jtisim-interfaces-2.json CODE :::  2
--- PASS: TestJTISIMMaxRun (50.00s)
    --- PASS: TestJTISIMMaxRun/multi-file-list-1gzip (25.00s)
    --- PASS: TestJTISIMMaxRun/multi-file-list-1 (25.00s)
=== RUN   TestVMXTagsPoints
=== RUN   TestVMXTagsPoints/interfaces
=== RUN   TestVMXTagsPoints/interfaces_uint64
--- PASS: TestVMXTagsPoints (5.55s)
    --- PASS: TestVMXTagsPoints/interfaces (1.97s)
    --- PASS: TestVMXTagsPoints/interfaces_uint64 (3.57s)
=== RUN   TestCompareStrings
=== RUN   TestCompareStrings/space-equal
=== RUN   TestCompareStrings/space-not-equal
=== RUN   TestCompareStrings/multiline-space-equal
=== RUN   TestCompareStrings/multiline-space-not-equal
--- PASS: TestCompareStrings (0.00s)
    --- PASS: TestCompareStrings/space-equal (0.00s)
    --- PASS: TestCompareStrings/space-not-equal (0.00s)
    --- PASS: TestCompareStrings/multiline-space-equal (0.00s)
    --- PASS: TestCompareStrings/multiline-space-not-equal (0.00s)
=== RUN   TestTestUtils
2023/09/07 02:22:37 data len = 17
--- PASS: TestTestUtils (0.00s)
PASS
coverage: 49.4% of statements
ok  	github.com/nileshsimaria/jtimon	186.084s
## go tool cover --html=coverage.out
go tool cover --func=coverage.out
github.com/nileshsimaria/jtimon/alias.go:17:			NewAlias			100.0%
github.com/nileshsimaria/jtimon/alias.go:41:			getAlias			100.0%
github.com/nileshsimaria/jtimon/config.go:104:			NewJTIMONConfigFilelist		100.0%
github.com/nileshsimaria/jtimon/config.go:111:			NewJTIMONConfig			100.0%
github.com/nileshsimaria/jtimon/config.go:117:			fillupDefaults			100.0%
github.com/nileshsimaria/jtimon/config.go:137:			ParseJSONConfigFileList		100.0%
github.com/nileshsimaria/jtimon/config.go:153:			ParseJSON			90.0%
github.com/nileshsimaria/jtimon/config.go:174:			ValidateConfig			75.0%
github.com/nileshsimaria/jtimon/config.go:184:			ExploreConfig			85.7%
github.com/nileshsimaria/jtimon/config.go:200:			IsVerboseLogging		100.0%
github.com/nileshsimaria/jtimon/config.go:205:			GetConfigFiles			75.0%
github.com/nileshsimaria/jtimon/config.go:226:			DecodePassword			23.1%
github.com/nileshsimaria/jtimon/config.go:246:			isConfigChanged			29.2%
github.com/nileshsimaria/jtimon/config.go:294:			HandleConfigChange		38.1%
github.com/nileshsimaria/jtimon/config.go:331:			ConfigRead			76.0%
github.com/nileshsimaria/jtimon/config.go:374:			StringInSlice			100.0%
github.com/nileshsimaria/jtimon/dialout.go:64:			newDialOutServer		0.0%
github.com/nileshsimaria/jtimon/dialout.go:108:			createRpc			0.0%
github.com/nileshsimaria/jtimon/dialout.go:114:			getUnusedRpcId			0.0%
github.com/nileshsimaria/jtimon/dialout.go:140:			createOrUpdateDeviceWithNewRpc	0.0%
github.com/nileshsimaria/jtimon/dialout.go:171:			removeRpcFromDevice		0.0%
github.com/nileshsimaria/jtimon/dialout.go:178:			DialOutSubscriber		0.0%
github.com/nileshsimaria/jtimon/dialout.go:316:			consumePartition		0.0%
github.com/nileshsimaria/jtimon/dialout.go:393:			populateAllConfig		0.0%
github.com/nileshsimaria/jtimon/dialout.go:421:			startDialOutServer		0.0%
github.com/nileshsimaria/jtimon/gnmi_utils.go:75:		xPathTognmiPath			87.0%
github.com/nileshsimaria/jtimon/gnmi_utils.go:114:		gnmiMode			100.0%
github.com/nileshsimaria/jtimon/gnmi_utils.go:126:		gnmiFreq			100.0%
github.com/nileshsimaria/jtimon/gnmi_utils.go:147:		gnmiParseUpdates		83.3%
github.com/nileshsimaria/jtimon/gnmi_utils.go:216:		gnmiParseDeletes		100.0%
github.com/nileshsimaria/jtimon/gnmi_utils.go:256:		gnmiParsePath			100.0%
github.com/nileshsimaria/jtimon/gnmi_utils.go:282:		gnmiParseValue			62.3%
github.com/nileshsimaria/jtimon/gnmi_utils.go:411:		formJuniperTelemetryHdr		80.0%
github.com/nileshsimaria/jtimon/grpc.go:14:			getSecurityOptions		33.3%
github.com/nileshsimaria/jtimon/grpc.go:41:			getGPRCDialOptions		77.8%
github.com/nileshsimaria/jtimon/influx.go:57:			newMetricIDB			100.0%
github.com/nileshsimaria/jtimon/influx.go:65:			accumulate			100.0%
github.com/nileshsimaria/jtimon/influx.go:71:			pointAcculumator		69.7%
github.com/nileshsimaria/jtimon/influx.go:224:			dbBatchWriteM			0.0%
github.com/nileshsimaria/jtimon/influx.go:307:			dbBatchWrite			83.3%
github.com/nileshsimaria/jtimon/influx.go:357:			spitTagsNPath			100.0%
github.com/nileshsimaria/jtimon/influx.go:397:			SubscriptionPathFromPath	100.0%
github.com/nileshsimaria/jtimon/influx.go:405:			mName				33.3%
github.com/nileshsimaria/jtimon/influx.go:422:			newRow				100.0%
github.com/nileshsimaria/jtimon/influx.go:430:			addIDB				65.2%
github.com/nileshsimaria/jtimon/influx.go:582:			getInfluxClient			72.7%
github.com/nileshsimaria/jtimon/influx.go:607:			queryIDB			71.4%
github.com/nileshsimaria/jtimon/influx.go:623:			closeInfluxClient		100.0%
github.com/nileshsimaria/jtimon/influx.go:627:			influxInit			78.3%
github.com/nileshsimaria/jtimon/influx.go:665:			checkAndCeilFloatValues		62.5%
github.com/nileshsimaria/jtimon/kafka-publish.go:36:		KafkaConnect			0.0%
github.com/nileshsimaria/jtimon/kafka-publish.go:105:		KafkaInit			44.4%
github.com/nileshsimaria/jtimon/kafka-publish.go:123:		addKafka			16.7%
github.com/nileshsimaria/jtimon/kafka-publish.go:147:		getCertPool			0.0%
github.com/nileshsimaria/jtimon/kafka-publish.go:164:		loadCert			0.0%
github.com/nileshsimaria/jtimon/kafka_consumer.go:16:		createKafkaConsumerGroup	0.0%
github.com/nileshsimaria/jtimon/kafka_consumer.go:61:		Setup				0.0%
github.com/nileshsimaria/jtimon/kafka_consumer.go:68:		Cleanup				0.0%
github.com/nileshsimaria/jtimon/kafka_consumer.go:74:		ConsumeClaim			0.0%
github.com/nileshsimaria/jtimon/logs.go:9:			jLog				60.0%
github.com/nileshsimaria/jtimon/logs.go:20:			logStop				100.0%
github.com/nileshsimaria/jtimon/logs.go:29:			logInit				72.2%
github.com/nileshsimaria/jtimon/main.go:52:			main				0.0%
github.com/nileshsimaria/jtimon/multi_vendor.go:19:		getVendor			77.8%
github.com/nileshsimaria/jtimon/multi_vendor.go:37:		newJuniperJUNOS			100.0%
github.com/nileshsimaria/jtimon/multi_vendor.go:47:		newCiscoIOSXR			100.0%
github.com/nileshsimaria/jtimon/multi_vendor.go:57:		newGNMI				100.0%
github.com/nileshsimaria/jtimon/prometheus_exporter.go:23:	promName			100.0%
github.com/nileshsimaria/jtimon/prometheus_exporter.go:41:	newJTIMONPExporter		100.0%
github.com/nileshsimaria/jtimon/prometheus_exporter.go:48:	processJTIMONMetric		91.7%
github.com/nileshsimaria/jtimon/prometheus_exporter.go:71:	Collect				100.0%
github.com/nileshsimaria/jtimon/prometheus_exporter.go:89:	Describe			100.0%
github.com/nileshsimaria/jtimon/prometheus_exporter.go:93:	getMapKey			100.0%
github.com/nileshsimaria/jtimon/prometheus_exporter.go:112:	addPrometheus			53.5%
github.com/nileshsimaria/jtimon/prometheus_exporter.go:194:	promInit			100.0%
github.com/nileshsimaria/jtimon/statshandler.go:27:		TagConn				100.0%
github.com/nileshsimaria/jtimon/statshandler.go:31:		TagRPC				100.0%
github.com/nileshsimaria/jtimon/statshandler.go:35:		HandleConn			100.0%
github.com/nileshsimaria/jtimon/statshandler.go:43:		HandleRPC			100.0%
github.com/nileshsimaria/jtimon/statshandler.go:61:		updateStats			100.0%
github.com/nileshsimaria/jtimon/statshandler.go:72:		updateStatsKV			100.0%
github.com/nileshsimaria/jtimon/statshandler.go:84:		periodicStats			91.3%
github.com/nileshsimaria/jtimon/statshandler.go:128:		printSummary			92.3%
github.com/nileshsimaria/jtimon/subscribe_cisco_iosxr.go:36:	GetRequestMetadata		0.0%
github.com/nileshsimaria/jtimon/subscribe_cisco_iosxr.go:44:	RequireTransportSecurity	0.0%
github.com/nileshsimaria/jtimon/subscribe_cisco_iosxr.go:48:	dialExtensionXR			0.0%
github.com/nileshsimaria/jtimon/subscribe_cisco_iosxr.go:71:	String				100.0%
github.com/nileshsimaria/jtimon/subscribe_cisco_iosxr.go:79:	newSchema			100.0%
github.com/nileshsimaria/jtimon/subscribe_cisco_iosxr.go:83:	String				100.0%
github.com/nileshsimaria/jtimon/subscribe_cisco_iosxr.go:93:	swalk				100.0%
github.com/nileshsimaria/jtimon/subscribe_cisco_iosxr.go:103:	getXRSchemaNode			75.0%
github.com/nileshsimaria/jtimon/subscribe_cisco_iosxr.go:117:	getXRSchemaPaths		90.9%
github.com/nileshsimaria/jtimon/subscribe_cisco_iosxr.go:139:	getXRSchema			75.0%
github.com/nileshsimaria/jtimon/subscribe_cisco_iosxr.go:178:	transformPath			100.0%
github.com/nileshsimaria/jtimon/subscribe_cisco_iosxr.go:197:	handleOnePath			0.0%
github.com/nileshsimaria/jtimon/subscribe_cisco_iosxr.go:294:	subscribeXR			0.0%
github.com/nileshsimaria/jtimon/subscribe_cisco_iosxr.go:331:	getKeysFromMessage		100.0%
github.com/nileshsimaria/jtimon/subscribe_cisco_iosxr.go:344:	getContentFromMessage		100.0%
github.com/nileshsimaria/jtimon/subscribe_cisco_iosxr.go:356:	getFieldStringValue		50.0%
github.com/nileshsimaria/jtimon/subscribe_cisco_iosxr.go:379:	getFieldValueInterface		100.0%
github.com/nileshsimaria/jtimon/subscribe_cisco_iosxr.go:405:	getKeyValue			100.0%
github.com/nileshsimaria/jtimon/subscribe_cisco_iosxr.go:415:	multiLevelMsgTags		92.3%
github.com/nileshsimaria/jtimon/subscribe_cisco_iosxr.go:471:	processMultiLevelMsg		100.0%
github.com/nileshsimaria/jtimon/subscribe_cisco_iosxr.go:482:	processTopLevelMsg		100.0%
github.com/nileshsimaria/jtimon/subscribe_cisco_iosxr.go:510:	String				100.0%
github.com/nileshsimaria/jtimon/subscribe_cisco_iosxr.go:514:	walk				86.1%
github.com/nileshsimaria/jtimon/subscribe_cisco_iosxr.go:584:	getParentPath			100.0%
github.com/nileshsimaria/jtimon/subscribe_cisco_iosxr.go:596:	printFields			0.0%
github.com/nileshsimaria/jtimon/subscribe_cisco_iosxr.go:617:	printOneField			0.0%
github.com/nileshsimaria/jtimon/subscribe_gnmi.go:30:		convToFloatForPrometheus	86.7%
github.com/nileshsimaria/jtimon/subscribe_gnmi.go:68:		publishToPrometheus		94.4%
github.com/nileshsimaria/jtimon/subscribe_gnmi.go:115:		publishToInflux			52.4%
github.com/nileshsimaria/jtimon/subscribe_gnmi.go:164:		gnmiParseHeader			69.2%
github.com/nileshsimaria/jtimon/subscribe_gnmi.go:240:		gnmiParseNotification		68.2%
github.com/nileshsimaria/jtimon/subscribe_gnmi.go:289:		gnmiHandleResponse		82.0%
github.com/nileshsimaria/jtimon/subscribe_gnmi.go:395:		xPathsTognmiSubscription	0.0%
github.com/nileshsimaria/jtimon/subscribe_gnmi.go:433:		subscribegNMI			0.0%
github.com/nileshsimaria/jtimon/subscribe_juniper_junos.go:32:	handleOnePacket			31.6%
github.com/nileshsimaria/jtimon/subscribe_juniper_junos.go:104:	subSendAndReceive		70.4%
github.com/nileshsimaria/jtimon/subscribe_juniper_junos.go:215:	subscribeJunos			100.0%
github.com/nileshsimaria/jtimon/subscribe_juniper_junos.go:232:	loginCheckJunos			18.2%
github.com/nileshsimaria/jtimon/testutils.go:21:		testSetup			70.0%
github.com/nileshsimaria/jtimon/testutils.go:38:		testTearDown			100.0%
github.com/nileshsimaria/jtimon/testutils.go:55:		generateTestData		100.0%
github.com/nileshsimaria/jtimon/testutils.go:66:		testDataPoints			83.3%
github.com/nileshsimaria/jtimon/testutils.go:115:		compareString			100.0%
github.com/nileshsimaria/jtimon/workers.go:61:			NewJWorkers			100.0%
github.com/nileshsimaria/jtimon/workers.go:73:			EndWorkers			100.0%
github.com/nileshsimaria/jtimon/workers.go:78:			SIGHUPWorkers			100.0%
github.com/nileshsimaria/jtimon/workers.go:86:			StartWorkers			100.0%
github.com/nileshsimaria/jtimon/workers.go:98:			Wait				100.0%
github.com/nileshsimaria/jtimon/workers.go:103:			AddWorkers			100.0%
github.com/nileshsimaria/jtimon/workers.go:112:			StartWorker			100.0%
github.com/nileshsimaria/jtimon/workers.go:123:			AddWorker			100.0%
github.com/nileshsimaria/jtimon/workers.go:130:			maxRunHandler			100.0%
github.com/nileshsimaria/jtimon/workers.go:143:			handleConfigChanges		92.3%
github.com/nileshsimaria/jtimon/workers.go:177:			signalHandler			73.3%
github.com/nileshsimaria/jtimon/workers.go:216:			getDialOutRequest		0.0%
github.com/nileshsimaria/jtimon/workers.go:249:			NewJWorker			54.7%
github.com/nileshsimaria/jtimon/workers.go:381:			LocalAddr			0.0%
github.com/nileshsimaria/jtimon/workers.go:384:			RemoteAddr			0.0%
github.com/nileshsimaria/jtimon/workers.go:387:			SetDeadline			0.0%
github.com/nileshsimaria/jtimon/workers.go:390:			SetReadDeadline			0.0%
github.com/nileshsimaria/jtimon/workers.go:393:			SetWriteDeadline		0.0%
github.com/nileshsimaria/jtimon/workers.go:401:			getBackOff			0.0%
github.com/nileshsimaria/jtimon/workers.go:410:			workTunnel			0.0%
github.com/nileshsimaria/jtimon/workers.go:631:			work				47.3%
total:								(statements)			49.4%